### PR TITLE
Update for confluence 9

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# This file is used by direnv to setup the local shell environment, whenever the project is entered.
+# Installation: https://direnv.net/#basic-installation
+
+use flake
+PATH=$PWD/cmds:$PATH

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
@@ -31,10 +31,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Start Confluence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         'distribution': temurin
-        java-version: '21'
+        java-version: '17'
 
     - name: Build with Maven 🔧
       run: mvn -B package --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Artifacts
         path: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /src/test/resources/signature-test.ser
 
+.direnv/
+
 /.settings
 /.classpath
 /.project

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750857704,
+        "narHash": "sha256-rhrs6acrbymLTmZQ18eUPTURTf9F9mKJZwesa2oqRPM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffdcefdde9a4e540d1c875767da0e382e1ccf460",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Confluence-Multitenancy Dev-Envirionment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      javaVersion = 17;
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
+      });
+    in
+    {
+      overlays.default =
+        final: prev: rec {
+          jdk = prev."jdk${toString javaVersion}";
+          maven = prev.maven.override { jdk_headless = jdk; };
+          kotlin = prev.kotlin.override { jre = jdk; };
+        };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+
+          packages = with pkgs; [
+            just
+            jdk
+            kotlin
+            maven
+          ];
+        };
+      });
+    };
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baloise.confluence</groupId>
     <artifactId>digital-signature</artifactId>
-    <version>8.0.0</version>
+    <version>8.0.1</version>
 
     <properties>
         <confluence.version>9.2.3</confluence.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.version>3.14.0</maven.compiler.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <allow.google.tracking>false</allow.google.tracking>
         <kotlin.version>2.1.20</kotlin.version>
-        <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
     </properties>
 
 
@@ -57,7 +57,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -66,6 +65,7 @@
             <version>${confluence.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>com.atlassian.mywork</groupId>
             <artifactId>mywork-api</artifactId>
@@ -211,6 +211,14 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <languageVersion>2.1</languageVersion>
+                    <apiVersion>2.1</apiVersion>
+                    <args>
+                        <arg>-Xwhen-guards</arg>
+                    </args>
+                </configuration>
+
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -282,20 +290,19 @@
                     <productDataVersion>${confluence.data.version}</productDataVersion>
                     <enableQuickReload>false</enableQuickReload>
                     <extractDependencies>false</extractDependencies>
+                    <banningExcludes>
+                        <exclude>com.google.code.gson:gson</exclude>
+                    </banningExcludes>
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
                         <!-- Add package to export here -->
                         <Export-Package>com.baloise.confluence.digitalsignature.api</Export-Package>
                         <!-- Add package import here -->
                         <Import-Package>
-                            com.atlassian.plugin.module,
-                            com.atlassian.plugin.osgi.external,
-                            org.eclipse.gemini.blueprint.*,
-                            org.osgi.framework,
-                            org.springframework.*,
-                            *,
+                            org.springframework.osgi.*;resolution:="optional",
+                            org.eclipse.gemini.blueprint.*;resolution:="optional",
+                            *;version="0";resolution:=optional
                         </Import-Package>
-
                         <!-- Ensure plugin is spring powered -->
                         <Spring-Context>*</Spring-Context>
                     </instructions>


### PR DESCRIPTION
- Revert to JDK 17
- Fix an issue where gson was not bundled and couldn't be provided by confluence